### PR TITLE
remove SDL2::RAW version requirement

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -6,7 +6,7 @@
   "description"   : "SDL2 with some OO-sugar.",
   "test-depends"  : [
     "Test",
-    "SDL2::Raw"
+    "SDL2::Raw:ver<0.2+>"
   ],
   "auth"          : "github:azawawi",
   "authors"       : [ "Ahmad M. Zawawi" ],

--- a/lib/SDL2/Renderer.pm6
+++ b/lib/SDL2/Renderer.pm6
@@ -4,9 +4,9 @@ use v6;
 unit class SDL2::Renderer;
 
 use NativeCall;
-use SDL2::Raw:ver(0.2);
+use SDL2::Raw;
 use SDL2::Window;
-  
+
 has SDL_Renderer $.renderer;
 
 method new(


### PR DESCRIPTION
hi there, here's a patch to fix the tests..

wasabi:perl6-sdl2 mason$ AUTHOR_TESTING=1 prove -e "perl6 -Ilib"
t/01-load.t ......... ok
t/99-author-meta.t .. ok
All tests successful.
Files=2, Tests=2,  1 wallclock secs ( 0.03 usr  0.01 sys +  1.62 cusr  0.14 csys =  1.80 CPU)
Result: PASS
